### PR TITLE
Turn page title into a link to the home page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
     <div id="header_wrap" class="outer">
         <header class="inner">
 
-          <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
+          <h1 id="project_title"><a href="{{site.baseurl}}">{{ site.title | default: site.github.repository_name }}</a></h1>
           <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
 
           {% if site.show_downloads %}


### PR DESCRIPTION
If you merge this, it will make your page titles links back to the home page, which is probably what you want.